### PR TITLE
Use HTTPS to clone plugins to please CI

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   flutter_map: ^2.0.0
   flutter_map_dragmarker:
     git:
-      url: git@github.com:eidolonFIRE/flutter_map_dragmarker.git
+      url: https://github.com/eidolonFIRE/flutter_map_dragmarker.git
   latlong2: ^0.8.0
 
 dev_dependencies:


### PR DESCRIPTION
In Github Actions, `flutter pub get` is failing because ssh is not set. Instead, I am trying to use https to specify the repo URL.